### PR TITLE
removed splay dynamic calibration, added splay scaling

### DIFF
--- a/firmware/lucidgloves-firmware/Config.h
+++ b/firmware/lucidgloves-firmware/Config.h
@@ -72,6 +72,12 @@
 #define FORCE_FEEDBACK_MAX   1000 // Value of 1000 means maximum limit.
 #define FORCE_FEEDBACK_RELEASE 50 // To prevent hardware damage, value passed the limit for when to release FFB. (Set to FORCE_FEEDBACK_MAX to disable)
 
+// Splay Scaling
+// Unit invariant as long as you use the same unit between the two variables
+#define POT_MAX_ANGLE    270
+#define DRIVER_MAX_ANGLE 40
+#define ANALOG_MID (ANALOG_MAX / 2) //expected resting splay value (can be chanched if your pots are not in the midle of their range when fingers are in resting position)
+
 // Counts of objects in the system used for looping
 // Inputs
 #define GESTURE_COUNT        (TRIGGER_GESTURE + GRAB_GESTURE + PINCH_GESTURE)

--- a/firmware/lucidgloves-firmware/Config.h
+++ b/firmware/lucidgloves-firmware/Config.h
@@ -74,8 +74,8 @@
 
 // Splay Scaling
 // Unit invariant as long as you use the same unit between the two variables
-#define POT_MAX_ANGLE    270
-#define DRIVER_MAX_ANGLE 40
+#define POT_MAX_SPLAY_ANGLE    270
+#define DRIVER_MAX_SPLAY_ANGLE 40
 #define ANALOG_MID (ANALOG_MAX / 2) //expected resting splay value (can be chanched if your pots are not in the midle of their range when fingers are in resting position)
 
 // Counts of objects in the system used for looping

--- a/firmware/lucidgloves-firmware/Finger.hpp
+++ b/firmware/lucidgloves-firmware/Finger.hpp
@@ -88,13 +88,12 @@ class SplayFinger : public Finger {
   void readInput() override {
     Finger::readInput();
     int new_splay_value = analogRead(splay_pin);
-    // Update the calibration
-    if (calibrate) {
-      splay_calibrator.update(new_splay_value);
-    }
+    
+    // map splay value to match max angle in driver
+    splay_value = map(new_splay_value, ANALOG_MID - DRIVER_MAX_ANGLE, ANALOG_MID + DRIVER_MAX_ANGLE, ANALOG_MID - POT_MAX_ANGLE, ANALOG_MID + POT_MAX_ANGLE);
 
-    // set the value to the calibrated value.
-    splay_value = splay_calibrator.calibrate(new_splay_value, 0, ANALOG_MAX);
+    // constrain splay value to 0 -> 4095 range.
+    splay_value = constrain(splay_value, 0, 4095);
   }
 
   inline int getEncodedSize() const override {

--- a/firmware/lucidgloves-firmware/Finger.hpp
+++ b/firmware/lucidgloves-firmware/Finger.hpp
@@ -90,7 +90,7 @@ class SplayFinger : public Finger {
     int new_splay_value = analogRead(splay_pin);
     
     // map splay value to match max angle in driver
-    splay_value = map(new_splay_value, ANALOG_MID - DRIVER_MAX_ANGLE, ANALOG_MID + DRIVER_MAX_ANGLE, ANALOG_MID - POT_MAX_ANGLE, ANALOG_MID + POT_MAX_ANGLE);
+    splay_value = map(new_splay_value, ANALOG_MID - DRIVER_MAX_SPLAY_ANGLE, ANALOG_MID + DRIVER_MAX_SPLAY_ANGLE, ANALOG_MID - POT_MAX_SPLAY_ANGLE, ANALOG_MID + POT_MAX_SPLAY_ANGLE);
 
     // constrain splay value to 0 -> 4095 range.
     splay_value = constrain(splay_value, 0, 4095);


### PR DESCRIPTION
first initial draft for splay scaling,

still a bit wounky because there's no real calibration for the resting position, so i'm just using 
"#define ANALOG_MID (ANALOG_MAX / 2)" in the meantime but it can be off depending on your potentiometers and their placements 

for calibration it should behave a bit like this:

-1 press calib button

-2 wait X amount of time (optional delay)

-3 redord splay_values for each fingers independantly for Y number of loops and average
    (so 5 arrays of Y lenght, averaged into 5 variables)

-4 offset is "average_splay_value - 2047" (<--this is also where we would put antother offset to compensate for the natural splay ingame if Dan doesn't want to bother doing it in the driver)
    (so 5 offsets, to be applied to their respective fingers on each loop,)

-5 apply offset to splay_value right before "splay_value = map(...);" line 93 in Finger.hpp
and replace "ANALOG_MID" with the "average_splay_value" (used to calulate the offset) in the map function for scaling